### PR TITLE
Fix typo in patch method

### DIFF
--- a/src/Rest.php
+++ b/src/Rest.php
@@ -98,7 +98,7 @@ class Rest
      */
     public function patch()
     {
-        $this->method = 'PATH';
+        $this->method = 'PATCH';
         return $this;
     }
     


### PR DESCRIPTION
There was a typo in the patch method which set the method to `PATH`