### PR TITLE
Issue #17: Implemented caching of response with cachable() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,28 @@ Other way
  }
 ```
 
+# Response Caching
+
+If the response of the microservice is likely to remain the same for periods of time, you may want to be polite and reduce requests to the service by caching the responses. This is also useful if the service imposes a request limit and you do not want to breach it with unnecessary calls.
+
+You can enable caching using the `->cachable()` method which accepts a period of time in seconds as it's only parameter. The following example will hold the response for 60 seconds before making the request again:
+
+```php
+$request = new \Maestro\Rest();
+
+$result = $request
+    ->get()
+    ->setUrl('http://api.example.com')
+    ->setEndPoint('/horses')
+    ->cachable(60)
+    ->send()
+    ->parse();
+```
+
+Caching functionality is dependent on the PHP package, [APCu](https://pecl.php.net/package/APCu) being installed and enabled in the environment.
+
+_Note: If you are developing and accidentally cache a bad response for a long period of time, simply make a request with `->cachable(0)` to overwrite previous caches._
+
 ## Senders
 You can send in 2 ways: synchronous or asynchronous. See the examples:
 

--- a/src/CachingGetters.php
+++ b/src/CachingGetters.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Maestro;
+
+trait CachingGetters
+{
+    public function getCachingEnabled()
+    {
+        return $this->cachingEnabled;
+    }
+
+    public function getCacheTime()
+    {
+        return $this->cacheTime;
+    }
+}

--- a/tests/RestTest.php
+++ b/tests/RestTest.php
@@ -31,7 +31,7 @@ class RestTest extends TestCase
     /**
      * Method testValidRestClass.
      */
-    public function testValidRestClass() : void
+    public function testValidRestClass()
     {
         $this->assertInstanceOf(Rest::class, $this->restClass);
     }
@@ -39,7 +39,7 @@ class RestTest extends TestCase
     /**
      * Method testGetSetUrl.
      */
-    public function testGetSetUrl() : void
+    public function testGetSetUrl()
     {
         $url = 'http://localhost';
         $this->assertInstanceOf(Rest::class, $this->restClass->setUrl($url));
@@ -49,7 +49,7 @@ class RestTest extends TestCase
     /**
      * Method testGetSetEndpoint.
      */
-    public function testGetSetEndpoint() : void
+    public function testGetSetEndpoint()
     {
         $endpoint = 'endpoint';
         $this->assertInstanceOf(Rest::class, $this->restClass->setEndpoint($endpoint));
@@ -59,7 +59,7 @@ class RestTest extends TestCase
     /**
      * Method testHeaders.
      */
-    public function testHeaders() : void
+    public function testHeaders()
     {
         $headers = [
             'http',
@@ -72,7 +72,7 @@ class RestTest extends TestCase
     /**
      * Method testBody.
      */
-    public function testBody() : void
+    public function testBody()
     {
         $body = [
             'body',
@@ -85,7 +85,7 @@ class RestTest extends TestCase
      * Method testSendGet()
      * Assert that the GuzzleClient forwards the request.
      */
-    public function testSendGet() : void
+    public function testSendGet()
     {
         $url = 'https://www.google.com';
         $mock = \Mockery::mock(new Client());
@@ -109,7 +109,7 @@ class RestTest extends TestCase
      * Assert that the Rest API raises an exception
      * when no method has been defined.
      */
-    public function testSendNoMethod() : void
+    public function testSendNoMethod()
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->restClass->send();
@@ -120,7 +120,7 @@ class RestTest extends TestCase
      * Assert that the Rest API raises an exception
      * when no url has been defined.
      */
-    public function testSendNoUrl() : void
+    public function testSendNoUrl()
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->restClass->get()->send();
@@ -129,7 +129,7 @@ class RestTest extends TestCase
     /**
      * Method testSendAsync.
      */
-    public function testSendAsync() : void
+    public function testSendAsync()
     {
         $this->markTestIncomplete('To implement');
     }
@@ -137,7 +137,7 @@ class RestTest extends TestCase
     /**
      * Method testGetResponse.
      */
-    public function testGetResponse() : void
+    public function testGetResponse()
     {
         $expectedReturnValue = 1;
         $mock = \Mockery::mock(new Client());
@@ -160,7 +160,7 @@ class RestTest extends TestCase
     /**
      * Method testParse.
      */
-    public function testParse() : void
+    public function testParse()
     {
         $mock = \Mockery::mock(new Client());
         $mock->shouldReceive('send')
@@ -182,8 +182,45 @@ class RestTest extends TestCase
     /**
      * Method testAssoc.
      */
-    public function testAssoc() : void
+    public function testAssoc()
     {
         $this->assertInstanceOf(Rest::class, $this->restClass->assoc());
+    }
+
+    public function testNotCachableByDefault()
+    {
+        $result = $this->restClass->get()
+                    ->setUrl('http://api.example.com')
+                    ->setEndPoint('/horses')
+                    ->getCachingEnabled();
+
+        $this->assertFalse($result);
+    }
+
+    public function testCachable()
+    {
+        $result = $this->restClass->get()
+                    ->setUrl('http://api.example.com')
+                    ->setEndPoint('/horses')
+                    ->cachable(60)
+                    ->getCachingEnabled();
+
+        $this->assertTrue($result);
+    }
+
+    public function testSetCacheTime()
+    {
+        $result = $this->restClass->get()
+                    ->cachable(360)
+                    ->getCacheTime();
+
+        $this->assertEquals($result, 360);
+    }
+
+    public function testPostRequestsNotCachable()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $rest = new Rest();
+        $result = $rest->post()->cachable(60);
     }
 }


### PR DESCRIPTION
Added caching of responses. 

I had to change the `parse()` method to use a new class-wide variable called `responseBody` which is a stringified version of `->getResponseBody()` because complex instances of classes cannot be cached so the contents of body is cached. Of course this means that if the result is being retrieved from cache, the response object is not available but I figured that's acceptable behaviour. 